### PR TITLE
Update boost to 1.87.0

### DIFF
--- a/io.github.martchus.syncthingtray.yml
+++ b/io.github.martchus.syncthingtray.yml
@@ -71,8 +71,8 @@ modules:
       - ./b2 --with-filesystem -j $FLATPAK_BUILDER_N_JOBS link=static install
     sources:
       - type: archive
-        url: https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2
-        sha256: 1bed88e40401b2cb7a1f76d4bab499e352fa4d0c5f31c0dbae64e24d34d7513b
+        url: https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.bz2
+        sha256: af57be25cb4c4f4b413ed692fe378affb4352ea50fbe294a11ef548f4d527d89
         x-checker-data:
           type: anitya
           project-id: 6845


### PR DESCRIPTION
As #21 described, boost is out of date. This PR update boost to 1.87.0.

And thanks to @flyingcakes85 for enabling us to promptly learn that the boost download link has been changed.