### PR TITLE
Bump runtime version to 6.11

### DIFF
--- a/io.github.martchus.syncthingtray.yml
+++ b/io.github.martchus.syncthingtray.yml
@@ -1,6 +1,6 @@
 id: io.github.martchus.syncthingtray
 runtime: org.kde.Platform
-runtime-version: '6.10'
+runtime-version: '6.11'
 sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.golang


### PR DESCRIPTION
Qt 6.10 is not tested by upstream; Qt 6.11 is.