### PR TITLE
Revert "Bump runtime version to 6.11"

### DIFF
--- a/io.github.martchus.syncthingtray.yml
+++ b/io.github.martchus.syncthingtray.yml
@@ -1,6 +1,6 @@
 id: io.github.martchus.syncthingtray
 runtime: org.kde.Platform
-runtime-version: '6.11'
+runtime-version: '6.10'
 sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.golang


### PR DESCRIPTION
Reverts flathub/io.github.martchus.syncthingtray#53 to workaround https://github.com/flathub/io.github.martchus.syncthingtray/issues/54